### PR TITLE
feat: Add price-related fields to item detail response including discount, vat_price, and additional_cost

### DIFF
--- a/bazaa/bazaa/api/items.py
+++ b/bazaa/bazaa/api/items.py
@@ -87,8 +87,11 @@ def item_detail(name):
             "item_name",
             "item_group",
             "image",
-            "price",
+             "price",
             "old_price",
+            "discount",
+            "vat_price",
+            "additional_cost",
             "description",
             "summary"
         ],


### PR DESCRIPTION
This pull request adds new fields to the `item_detail` API response in `bazaa/bazaa/api/items.py` to provide more comprehensive pricing information.

Enhancements to API response:

* [`bazaa/bazaa/api/items.py`](diffhunk://#diff-2cb2b655f7435786e9c366e6d06811f03b6ffa9d9ebebc1d1ee328e5b887ca39R92-R94): Added `discount`, `vat_price`, and `additional_cost` fields to the `item_detail` function's response to include detailed pricing breakdowns.