### PR TITLE
feat: Update sales order item rate to use total_price instead of price

### DIFF
--- a/bazaa/bazaa/api/order.py
+++ b/bazaa/bazaa/api/order.py
@@ -40,7 +40,7 @@ def create_sales_order():
             sales_order.append("items", {
                 "item_code": item_code,
                 "qty": item_data.get("quantity", 1),
-                "rate": item_data.get("price", 0),
+                "rate": item_data.get("total_price", 0),
                 "delivery_date": frappe.utils.add_days(frappe.utils.nowdate(), 7),
                 "warehouse": default_warehouse 
             })


### PR DESCRIPTION
This pull request includes a small but important change to the `create_sales_order` function in `bazaa/bazaa/api/order.py`. The change updates the key used to fetch the rate for sales order items from `price` to `total_price`, ensuring the correct value is used when creating sales orders.