### PR TITLE
feat: Add Website Enquiry functionality with email notification and data handling

### DIFF
--- a/bazaa/bazaa/api/cutting.py
+++ b/bazaa/bazaa/api/cutting.py
@@ -32,10 +32,14 @@ def create_cutting_list():
                 "width": item.get("width"),
                 "qty": item.get("qty"),
                 "description": item.get("description"),
-                "edging_length": item.get("edging_length") or 0,
-                "edging_width": item.get("edging_width") or 0,
-                "grooves_length": item.get("grooves_length") or 0,
-                "grooves_width": item.get("grooves_width") or 0,
+                "edging_l1": item.get("edging_l1") or 0,
+                "edging_l2": item.get("edging_l2") or 0,
+                "edging_w1": item.get("edging_w1") or 0,
+                "edging_w2": item.get("edging_w2") or 0,
+                "grooves_l1": item.get("grooves_l1") or 0,
+                "grooves_l2": item.get("grooves_l2") or 0,
+                "grooves_w1": item.get("grooves_w1") or 0,
+                "grooves_w2": item.get("grooves_w2") or 0,
             })
 
         # Insert the document

--- a/bazaa/bazaa/api/website.py
+++ b/bazaa/bazaa/api/website.py
@@ -1,0 +1,38 @@
+import frappe
+from frappe import _
+import json
+
+@frappe.whitelist(allow_guest=True)
+def equiry():
+    try:
+        # Parse incoming data
+        data = frappe.local.form_dict or {}
+        if isinstance(data, str):
+            data = json.loads(data)
+
+        # Required fields
+        first_name = data.get("first_name")
+        message = data.get("message")
+
+        if not first_name or not message:
+            return {"status": "error", "message": "First name and message are required."}
+
+        # Create new Website Enquiry document
+        enquiry = frappe.get_doc({
+            "doctype": "Website Enquiry",
+            "first_name": first_name,
+            "last_name": data.get("last_name"),
+            "email": data.get("email"),
+            "phone": data.get("phone"),
+            "message": message,
+        })
+
+        # Insert and submit the document
+        enquiry.insert(ignore_permissions=True)
+        enquiry.submit()
+
+        return {"status": "success", "message": "Enquiry submitted successfully.", "enquiry_id": enquiry.name}
+
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "Website Enquiry API Error")
+        return {"status": "error", "message": "Failed to submit enquiry.", "details": str(e)}

--- a/bazaa/bazaa/doctype/cutting_list/cutting_list.py
+++ b/bazaa/bazaa/doctype/cutting_list/cutting_list.py
@@ -28,7 +28,8 @@ class CuttingList(Document):
 
 		# Prepare item headers
 		item_headers = ["Length", "Width", "Qty", "Description",
-						"Edging Length", "Edging Width", "Grooves Length", "Grooves Width"]
+						"Edging L1", "Edging L2", "Edging W1", "Edging W2",
+						"Grooves L1", "Grooves L2", "Grooves W1", "Grooves W2"]
 
 		# Prepare item data rows
 		item_rows = []
@@ -38,10 +39,14 @@ class CuttingList(Document):
 				item.width,
 				item.qty,
 				item.description,
-				1 if item.edging_length else 0,
-				1 if item.edging_width else 0,
-				1 if item.grooves_length else 0,
-				1 if item.grooves_width else 0
+				1 if item.edging_l1 else 0,
+				1 if item.edging_l2 else 0,
+				1 if item.edging_w1 else 0,
+				1 if item.edging_w2 else 0,
+				1 if item.grooves_l1 else 0,
+				1 if item.grooves_l2 else 0,
+				1 if item.grooves_w1 else 0,
+				1 if item.grooves_w2 else 0
 			])
 
 		# Combine all into one sheet
@@ -67,4 +72,3 @@ class CuttingList(Document):
 		)
 
 		frappe.msgprint(f"Cutting list sent to {default_email}")
-

--- a/bazaa/bazaa/doctype/cutting_list_item/cutting_list_item.json
+++ b/bazaa/bazaa/doctype/cutting_list_item/cutting_list_item.json
@@ -14,11 +14,17 @@
   "description",
   "section_break_lyqm",
   "edging_column",
-  "edging_length",
-  "edging_width",
+  "edging_l1",
+  "edging_l2",
+  "column_break_ufsc",
+  "edging_w1",
+  "edging_w2",
   "grooves_column",
-  "grooves_length",
-  "grooves_width"
+  "grooves_l1",
+  "grooves_l2",
+  "column_break_xhql",
+  "grooves_w2",
+  "grooves_w1"
  ],
  "fields": [
   {
@@ -29,7 +35,7 @@
   {
    "allow_in_quick_entry": 1,
    "bold": 1,
-   "columns": 2,
+   "columns": 1,
    "fieldname": "length",
    "fieldtype": "Float",
    "in_filter": 1,
@@ -41,7 +47,7 @@
   {
    "allow_in_quick_entry": 1,
    "bold": 1,
-   "columns": 2,
+   "columns": 1,
    "fieldname": "width",
    "fieldtype": "Float",
    "in_filter": 1,
@@ -77,64 +83,114 @@
   },
   {
    "fieldname": "edging_column",
-   "fieldtype": "Column Break",
-   "label": "Edging"
-  },
-  {
-   "columns": 1,
-   "default": "0",
-   "fieldname": "edging_length",
-   "fieldtype": "Check",
-   "in_filter": 1,
-   "in_list_view": 1,
-   "in_preview": 1,
-   "in_standard_filter": 1,
-   "label": "Edging Length"
-  },
-  {
-   "columns": 1,
-   "default": "0",
-   "fieldname": "edging_width",
-   "fieldtype": "Check",
-   "in_filter": 1,
-   "in_list_view": 1,
-   "in_preview": 1,
-   "in_standard_filter": 1,
-   "label": "Edging Width"
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "grooves_column",
-   "fieldtype": "Column Break",
-   "label": "Grooves"
+   "fieldtype": "Column Break"
   },
   {
    "columns": 1,
    "default": "0",
-   "fieldname": "grooves_length",
+   "fieldname": "edging_l1",
    "fieldtype": "Check",
    "in_filter": 1,
    "in_list_view": 1,
    "in_preview": 1,
    "in_standard_filter": 1,
-   "label": "Grooves Length"
+   "label": "Edging L1"
   },
   {
    "columns": 1,
    "default": "0",
-   "fieldname": "grooves_width",
+   "fieldname": "edging_l2",
    "fieldtype": "Check",
    "in_filter": 1,
    "in_list_view": 1,
    "in_preview": 1,
    "in_standard_filter": 1,
-   "label": "Grooves Width"
+   "label": "Edging L2"
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "edging_w1",
+   "fieldtype": "Check",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Edging W1"
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "edging_w2",
+   "fieldtype": "Check",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Edging W2"
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "grooves_l1",
+   "fieldtype": "Check",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Grooves L1"
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "grooves_l2",
+   "fieldtype": "Check",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Grooves L2"
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "grooves_w1",
+   "fieldtype": "Check",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Grooves W1"
+  },
+  {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "grooves_w2",
+   "fieldtype": "Check",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_preview": 1,
+   "in_standard_filter": 1,
+   "label": "Grooves W2"
+  },
+  {
+   "fieldname": "column_break_ufsc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_xhql",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-09 09:00:46.838839",
+ "modified": "2025-06-10 09:38:20.950007",
  "modified_by": "Administrator",
  "module": "Bazaa",
  "name": "Cutting List Item",

--- a/bazaa/bazaa/doctype/website_enquiry/test_website_enquiry.py
+++ b/bazaa/bazaa/doctype/website_enquiry/test_website_enquiry.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, David Gitau and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestWebsiteEnquiry(FrappeTestCase):
+	pass

--- a/bazaa/bazaa/doctype/website_enquiry/website_enquiry.js
+++ b/bazaa/bazaa/doctype/website_enquiry/website_enquiry.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, David Gitau and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Website Enquiry", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/bazaa/bazaa/doctype/website_enquiry/website_enquiry.json
+++ b/bazaa/bazaa/doctype/website_enquiry/website_enquiry.json
@@ -1,0 +1,107 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "naming_series:",
+ "creation": "2025-06-10 08:51:45.517933",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "first_name",
+  "last_name",
+  "naming_series",
+  "column_break_wnwj",
+  "phone",
+  "email",
+  "section_break_mash",
+  "message",
+  "section_break_dadg",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_dadg",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Website Enquiry",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "first_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "First Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "last_name",
+   "fieldtype": "Data",
+   "label": "Last Name"
+  },
+  {
+   "fieldname": "column_break_wnwj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "phone",
+   "fieldtype": "Data",
+   "label": "Phone"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email"
+  },
+  {
+   "fieldname": "section_break_mash",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "message",
+   "fieldtype": "Long Text",
+   "label": "Message",
+   "reqd": 1
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "options": "ENQ-.YY.-.MM.-."
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-06-10 09:00:43.424361",
+ "modified_by": "Administrator",
+ "module": "Bazaa",
+ "name": "Website Enquiry",
+ "naming_rule": "By \"Naming Series\" field",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/bazaa/bazaa/doctype/website_enquiry/website_enquiry.py
+++ b/bazaa/bazaa/doctype/website_enquiry/website_enquiry.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, David Gitau and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+class WebsiteEnquiry(Document):
+    def on_submit(self):
+        self.send_enquiry_email()
+
+    def send_enquiry_email(self):
+        # Get the default email from Website Settings or your own settings doctype
+        default_email = frappe.db.get_single_value("Sales Settings", "default_email")
+        if not default_email:
+            frappe.msgprint("No default enquiry email configured in Website Settings.")
+            return
+
+        # Construct the message
+        message = f"""
+        <h3>New Website Enquiry Submitted</h3>
+        <p><strong>Name:</strong> {self.first_name} {self.last_name or ""}</p>
+        <p><strong>Email:</strong> {self.email}</p>
+        <p><strong>Phone:</strong> {self.phone or "N/A"}</p>
+        <p><strong>Message:</strong><br>{self.message}</p>
+        """
+
+        # Send the email
+        frappe.sendmail(
+            recipients=[default_email],
+            subject=f"New Enquiry: {self.name}",
+            message=message,
+            delayed=False  # Send immediately
+        )
+
+        frappe.msgprint(f"Enquiry email sent to {default_email}")


### PR DESCRIPTION
This pull request introduces significant updates to the cutting list functionality and adds a new "Website Enquiry" feature. The most important changes include restructuring the cutting list data model, enhancing the cutting list Excel export, and implementing the "Website Enquiry" API with its associated backend logic and document type.

### Cutting List Updates:

* Updated the cutting list data model to replace generic length/width fields (`edging_length`, `edging_width`, etc.) with more specific fields (`edging_l1`, `edging_l2`, etc.) for better granularity. [[1]](diffhunk://#diff-f52af0e3c8bad781c78dc0ff5d83f39c566727533b55321130116ab8c1b2b605L35-R42) [[2]](diffhunk://#diff-23d7bc13bddf153dc0ebae3328a8a3ee01ce15bc31bf8f574e993340db72f27bL17-R27)
* Adjusted the Excel export headers and data rows in `send_cutting_list_excel` to reflect the new field structure. [[1]](diffhunk://#diff-7354e87ac5688391e7a926f57e623508f01f4cae7cc5a4dac11b2e307a71c057L31-R32) [[2]](diffhunk://#diff-7354e87ac5688391e7a926f57e623508f01f4cae7cc5a4dac11b2e307a71c057L41-R49)

### Website Enquiry Feature:

* Added a new `Website Enquiry` DocType with fields for capturing user details (e.g., first name, email, message) and support for submission and email notifications. [[1]](diffhunk://#diff-c7aad125d37aa5ce021691e118793895ca02d97114b344df1b7c1b3475b03d69R1-R107) [[2]](diffhunk://#diff-79bf7e0ea1ae192907bd57a636940cec5c173ecb6665f5489a87d482cbde132eR1-R35)
* Implemented an API endpoint `equiry()` to handle website enquiries, including validation, document creation, and error handling.
* Added a test class `TestWebsiteEnquiry` as a placeholder for future tests.

### Minor Adjustments:

* Removed unused labels and adjusted column structures in the `cutting_list_item` JSON to align with the new field definitions.
* Added placeholder JavaScript for the `Website Enquiry` form.