### PR TITLE
feat: Enhance sales order creation with email notifications and update cutting list naming convention

### DIFF
--- a/bazaa/bazaa/api/order.py
+++ b/bazaa/bazaa/api/order.py
@@ -50,6 +50,40 @@ def create_sales_order():
         sales_order.insert(ignore_permissions=True)
         sales_order.submit()
         
+         # === Send Email ===
+        default_email = frappe.db.get_single_value("Sales Settings", "default_email")
+        customer_email = data.get("email")  # Optional: fallback to sending to customer if email is in request
+
+        subject = f"New Sales Order: {sales_order.name}"
+        content = f"""
+        A new Sales Order has been created.
+
+        <b>Order ID:</b> {sales_order.name}<br>
+        <b>Customer:</b> {sales_order.customer}<br>
+        <b>Delivery Date:</b> {sales_order.delivery_date}<br><br>
+
+        <b>Items:</b><br>
+        <ul>
+        {''.join(f"<li>{row.item_code} - Qty: {row.qty}, Rate: {row.rate}</li>" for row in sales_order.items)}
+        </ul>
+        """
+
+        # Send to default email
+        if default_email:
+            frappe.sendmail(
+                recipients=[default_email],
+                subject=subject,
+                message=content
+            )
+
+        # Optionally send to customer email if provided
+        if customer_email:
+            frappe.sendmail(
+                recipients=[customer_email],
+                subject=subject,
+                message=content
+            )
+        
         return {
             "id": sales_order.name,
             "status": "success",

--- a/bazaa/bazaa/doctype/cutting_list/cutting_list.json
+++ b/bazaa/bazaa/doctype/cutting_list/cutting_list.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "autoincrement",
+ "allow_rename": 1,
  "creation": "2025-06-09 08:41:22.644184",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -66,11 +66,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-09 09:18:46.810382",
+ "modified": "2025-06-17 08:35:45.390145",
  "modified_by": "Administrator",
  "module": "Bazaa",
  "name": "Cutting List",
- "naming_rule": "Autoincrement",
+ "naming_rule": "By script",
  "owner": "Administrator",
  "permissions": [
   {

--- a/bazaa/bazaa/doctype/cutting_list/cutting_list.py
+++ b/bazaa/bazaa/doctype/cutting_list/cutting_list.py
@@ -9,6 +9,14 @@ import csv
 from datetime import datetime
 
 class CuttingList(Document):
+	def autoname(self):
+		# Get current date and time in format DDMMYYhhmm
+		current_datetime = datetime.now().strftime("%d%m%y%H%M")
+		
+		# Create document name according to format Name#BoardType#dayandtime
+		document_name = f"{self.customer_name}#{self.board_type or ''}#{current_datetime}"
+		self.name = document_name  # Set the name of the document
+
 	def on_submit(self):
 		self.send_cutting_list_csv()
 
@@ -19,11 +27,6 @@ class CuttingList(Document):
 			frappe.msgprint("No default email configured in Sales Settings.")
 			return
 
-		# Get current date and time in format DDMMYYhhmm
-		current_datetime = datetime.now().strftime("%d%m%y%H%M")
-		
-		# Create document name according to format Name#BoardType#dayandtime
-		document_name = f"{self.customer_name}#{self.board_type or ''}#{current_datetime}"
 
 		# Prepare item headers
 		item_headers = ["Length", "Width", "Qty",
@@ -58,13 +61,13 @@ class CuttingList(Document):
 		file_content = io.BytesIO(csv_buffer.getvalue().encode('utf-8'))
 
 		# Save to File doctype
-		file_name = f"{document_name}.csv"
+		file_name = f"{self.name}.csv"
 		saved_file = save_file(file_name, file_content.getvalue(), self.doctype, self.name, is_private=True)
 
 		# Send email immediately
 		frappe.sendmail(
 			recipients=[default_email],
-			subject=f"Cutting List: {document_name}",
+			subject=f"Cutting List: {self.name}",
 			message="Please find the attached cutting list.",
 			attachments=[{
 				"fname": file_name,


### PR DESCRIPTION
This pull request introduces email notifications for sales orders, updates the naming convention for the `Cutting List` doctype, and improves the handling of file names and email subjects in the cutting list functionality. Below is a breakdown of the key changes:

### Email Notifications for Sales Orders
* Added functionality to send email notifications when a sales order is created. Emails are sent to a default email address from "Sales Settings" and optionally to the customer's email if provided. The email includes details such as the order ID, customer, delivery date, and items. (`bazaa/bazaa/api/order.py`)

### Updates to `Cutting List` Doctype
* Changed the naming rule for the `Cutting List` doctype from "Autoincrement" to "By script" and enabled renaming of documents. (`bazaa/bazaa/doctype/cutting_list/cutting_list.json`) [[1]](diffhunk://#diff-22ec54591246a2739de2a232a339af85c13fc183a7888ea0172c91c21d34db29L3-R3) [[2]](diffhunk://#diff-22ec54591246a2739de2a232a339af85c13fc183a7888ea0172c91c21d34db29L69-R73)
* Implemented a custom naming method in the `autoname` function to generate document names in the format `CustomerName#BoardType#DDMMYYhhmm`. (`bazaa/bazaa/doctype/cutting_list/cutting_list.py`)

### Improvements to Cutting List File Handling
* Updated the file naming logic in `send_cutting_list_csv` to use the document's name instead of generating a new name dynamically. (`bazaa/bazaa/doctype/cutting_list/cutting_list.py`)
* Adjusted the email subject in `send_cutting_list_csv` to align with the updated naming convention. (`bazaa/bazaa/doctype/cutting_list/cutting_list.py`)

These changes enhance the user experience by automating notifications, providing meaningful document names, and improving consistency in file handling.