### PR TITLE
feat: Update Cutting List document naming convention to include custo…

### DIFF
--- a/bazaa/bazaa/doctype/cutting_list/cutting_list.py
+++ b/bazaa/bazaa/doctype/cutting_list/cutting_list.py
@@ -14,7 +14,7 @@ class CuttingList(Document):
 		current_datetime = datetime.now().strftime("%d%m%y%H%M")
 		
 		# Create document name according to format Name#BoardType#dayandtime
-		document_name = f"{self.customer_name}#{self.board_type or ''}#{current_datetime}"
+		document_name = f"{self.customer_name}#{self.board_type or ''}#{self.customer_phone}#{current_datetime}"
 		self.name = document_name  # Set the name of the document
 
 	def on_submit(self):


### PR DESCRIPTION
This pull request introduces a small change to the `autoname` method in `bazaa/bazaa/doctype/cutting_list/cutting_list.py`. The change updates the document naming format to include the customer's phone number.

* [`bazaa/bazaa/doctype/cutting_list/cutting_list.py`](diffhunk://#diff-7354e87ac5688391e7a926f57e623508f01f4cae7cc5a4dac11b2e307a71c057L17-R17): Modified the `autoname` method to include the `customer_phone` attribute in the document name format