### PR TITLE
feat: Add frappe dependencies section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
 ]
 
+[tool.bench.frappe-dependencies]
+frappe = ">=14.0.0,<18.0.0"
+
 [build-system]
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
This pull request makes a minor update to the `pyproject.toml` file by specifying the supported `frappe` dependency versions in a new section. This clarifies the compatible version range for `frappe` in the project configuration.

* Added a `[tool.bench.frappe-dependencies]` section to declare `frappe` as compatible with versions `>=14.0.0,<18.0.0` in `pyproject.toml`.